### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@ ROC - Remote Object Call
 ========================
 
 [![Build Status](https://travis-ci.org/peterdemin/python-roc.png?branch=master)](https://travis-ci.org/peterdemin/python-roc)
-[![PyPi version](https://pypip.in/v/roc/badge.png)](https://crate.io/packages/roc/)
+[![PyPi version](https://img.shields.io/pypi/v/roc.svg)](https://crate.io/packages/roc/)
 
 ROC is thin wrapper around SimpleXMLRPCServer allowing to manipulate remote objects like they are local.
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20roc))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `roc`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.